### PR TITLE
Initialize Advanced Lab Handbook scaffolding

### DIFF
--- a/.github/workflows/jb.yml
+++ b/.github/workflows/jb.yml
@@ -1,0 +1,59 @@
+name: Build and Deploy Jupyter Book
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-book:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r binder/requirements.txt
+
+      - name: Build Jupyter Book
+        run: jupyter-book build .
+
+      - name: Upload built book as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: jupyter-book-html
+          path: _build/html
+
+  deploy-pages:
+    needs: build-book
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: jupyter-book-html
+          path: _site
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Jupyter Book build artifacts
+_build/
+
+# Jupyter notebook checkpoints
+.ipynb_checkpoints/
+
+# Python bytecode
+__pycache__/
+*.pyc

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,13 @@
+Text and figures — CC BY 4.0; Code — MIT License
+===============================================
+
+Text and figures in this repository are licensed under the Creative Commons Attribution 4.0 International License. You can view the full license at https://creativecommons.org/licenses/by/4.0/.
+
+The code (including scripts, notebooks, and configuration files) is licensed under the MIT License below.
+
 MIT License
 
-Copyright (c) 2025 adv-labs-ufr
+Copyright (c) 2025 Physikalisches Institut, Universität Freiburg
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,67 @@
-# handbook
-Interactive handbook for the Advanced Laboratory Courses (FP-I, FP-II, FP-EDU). Built with Jupyter Book, version-controlled on GitHub, and linked to ILIAS for schedules and grading. Includes background theory, experiment guides, and reproducible analysis tutorials executable on Binder.
+# Advanced Lab Handbook
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/UniFreiburg-Physics/advanced-lab-handbook/main?labpath=tutorials%2Fgaussian_fit.ipynb)
+
+The Advanced Lab Handbook provides openly accessible learning materials for the Advanced Laboratory Classes (FP-I, FP-II, FP-EDU) at the Physikalisches Institut, Universität Freiburg. This repository hosts a Jupyter Book that consolidates safety information, experiment documentation, and reproducible data-analysis tutorials. While the handbook delivers context, data, and worked examples, ILIAS remains the authoritative platform for schedules, quizzes, and grading.
+
+## Repository goals
+
+- Maintain a single source of truth for laboratory instructions and analysis workflows.
+- Offer executable notebooks through Binder for rapid prototyping and classroom demonstrations.
+- Encourage contributions from instructors, tutors, and students via transparent version control.
+
+## Getting started
+
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/UniFreiburg-Physics/advanced-lab-handbook.git
+   cd advanced-lab-handbook
+   ```
+2. **Create a virtual environment (optional but recommended)**
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r binder/requirements.txt
+   ```
+3. **Build the Jupyter Book locally**
+   ```bash
+   jupyter-book build .
+   ```
+   The rendered HTML will be available under `_build/html`. Open `index.html` in your browser to preview the site.
+
+## Repository structure
+
+```
+advanced-lab-handbook/
+├── _config.yml              # Global Jupyter Book configuration
+├── _toc.yml                 # Table of contents defining the book structure
+├── general-guidelines/      # Shared lab policies and preparation resources
+├── experiments/raman/       # Example experiment folder (Raman spectroscopy)
+├── tutorials/               # Interactive notebooks and analysis walkthroughs
+├── binder/                  # Binder configuration (requirements + postBuild)
+└── .github/workflows/       # Continuous integration for automated book builds
+```
+
+Additional experiment modules can be added under `experiments/`, and further tutorials can be contributed to `tutorials/`.
+
+## Continuous integration & deployment
+
+GitHub Actions automatically builds the Jupyter Book on every push to the `main` branch. Successful builds are published to GitHub Pages, ensuring that the online handbook stays in sync with the repository. The workflow installs dependencies from `binder/requirements.txt` and runs `jupyter-book build .` to verify the site.
+
+## Using Binder
+
+Click the Binder badge at the top of this README or open the [Gaussian fit tutorial on Binder](https://mybinder.org/v2/gh/UniFreiburg-Physics/advanced-lab-handbook/main?labpath=tutorials%2Fgaussian_fit.ipynb) directly. Binder launches an ephemeral environment with JupyterLab, preconfigured packages (NumPy, SciPy, Matplotlib, Pandas, Jupyter Book), and a post-build message confirming readiness.
+
+## Contributing
+
+1. Fork the repository and create a feature branch.
+2. Add or update content within the appropriate section (e.g., `general-guidelines/`, `experiments/`, `tutorials/`).
+3. Run `jupyter-book build .` to ensure the site compiles without warnings or errors.
+4. Open a pull request describing your changes. Remember to include data files or notebooks necessary to reproduce results.
+
+## License
+
+- **Text and figures**: Licensed under [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/).
+- **Code examples and scripts**: Licensed under the [MIT License](./LICENSE).
+
+By contributing, you agree that your submissions will be distributed under these terms.

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,20 @@
+title: "Advanced Lab Handbook"
+author: "Physikalisches Institut, Universität Freiburg"
+execute:
+  execute_notebooks: "off"
+html:
+  use_repository_button: true
+  use_edit_page_button: true
+  use_issues_button: true
+repository:
+  url: https://github.com/UniFreiburg-Physics/advanced-lab-handbook
+  path_to_book: .
+  branch: main
+launch_buttons:
+  binderhub_url: https://mybinder.org
+  notebook_interface: jupyterlab
+sphinx:
+  config:
+    exclude_patterns:
+      - README.md
+      - _build

--- a/_toc.yml
+++ b/_toc.yml
@@ -1,0 +1,6 @@
+format: jb-book
+root: index
+chapters:
+  - file: general-guidelines/overview
+  - file: tutorials/gaussian_fit
+  - file: experiments/raman/introduction

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+echo "Binder environment for the Advanced Lab Handbook is ready!"

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,6 @@
+jupyterlab
+numpy
+scipy
+matplotlib
+pandas
+jupyter-book

--- a/experiments/raman/introduction.md
+++ b/experiments/raman/introduction.md
@@ -1,0 +1,7 @@
+# Raman Spectroscopy Experiment
+
+This section will contain the experimental procedure, theoretical background, and analysis workflow for the Raman spectroscopy module.
+
+```{important}
+Ensure all safety interlocks are engaged before operating the laser source.
+```

--- a/general-guidelines/overview.md
+++ b/general-guidelines/overview.md
@@ -1,0 +1,7 @@
+# General Laboratory Guidelines
+
+This chapter will outline safety protocols, reporting standards, and recommended laboratory practices for all advanced lab courses.
+
+```{note}
+Content will be added as the handbook is developed collaboratively.
+```

--- a/index.md
+++ b/index.md
@@ -1,0 +1,3 @@
+# Advanced Lab Handbook
+
+Welcome to the Advanced Laboratory Classes handbook for the University of Freiburg. This resource provides quick links to guidelines, experiment documentation, and interactive tutorials to support FP-I, FP-II, and FP-EDU.

--- a/tutorials/gaussian_fit.ipynb
+++ b/tutorials/gaussian_fit.ipynb
@@ -1,0 +1,73 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c85503eb",
+   "metadata": {},
+   "source": [
+    "# Gaussian Fit Tutorial\n",
+    "\n",
+    "This notebook demonstrates how to perform a simple Gaussian fit using NumPy and SciPy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f39a1f3d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from scipy.optimize import curve_fit\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df05f403",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rng = np.random.default_rng(42)\n",
+    "x = np.linspace(-5, 5, 200)\n",
+    "true_params = (1.0, 0.0, 1.5)\n",
+    "def gaussian(x, amplitude, mean, sigma):\n",
+    "    return amplitude * np.exp(-((x - mean) ** 2) / (2 * sigma ** 2))\n",
+    "y = gaussian(x, *true_params) + 0.05 * rng.standard_normal(x.size)\n",
+    "popt, pcov = curve_fit(gaussian, x, y, p0=(0.8, -0.2, 1.0))\n",
+    "popt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "93093214",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(6, 4))\n",
+    "plt.scatter(x, y, s=10, label='Data')\n",
+    "plt.plot(x, gaussian(x, *popt), color='crimson', label='Fit')\n",
+    "plt.legend()\n",
+    "plt.xlabel('x')\n",
+    "plt.ylabel('Intensity')\n",
+    "plt.title('Gaussian Fit Example')\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add Jupyter Book configuration, initial content structure, and placeholder pages for guidelines, tutorials, and Raman experiment notes
- configure Binder environment and automation artifacts for reproducible execution, including requirements and postBuild message
- set up GitHub Actions workflow to build and deploy the Jupyter Book to GitHub Pages and update README/license to reflect project scope and licensing

## Testing
- jupyter-book build .

------
https://chatgpt.com/codex/tasks/task_e_68e65ebcbd1c8333acefef7c42f5b19c