### PR TITLE
Add prerequisites and library reference pages

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -8,6 +8,7 @@ parts:
       - file: general-info/safety
       - file: general-info/writing
       - file: general-info/seminar
+      - file: general-info/prerequisites
 
   - caption: Experiments
     chapters:
@@ -19,5 +20,6 @@ parts:
     chapters:
       - file: appendix/data-analysis/overview
       - file: appendix/data-analysis/uncertainty
+      - file: appendix/library
       - file: appendix/references
       - file: appendix/templates

--- a/appendix/library.md
+++ b/appendix/library.md
@@ -1,0 +1,45 @@
+# Library (Books & Key References)
+
+A compact list of **recommended books**, **method references**, and **official documents**. Use this as a starting point; tutors may suggest additional sources for specific experiments.
+
+---
+
+## Official Documents (Freiburg)
+- **M.Sc. Physics, Handbook of Modules (PO 2020)**  
+  <https://www.physik.uni-freiburg.de/bilderunddateien/dateien/MSc_Phys_Modulhandbuch_01.01.24.pdf>
+
+- **Lab Courses (overview)**  
+  <https://www.physik.uni-freiburg.de/studium-en/labore-en>
+
+*(Administrative items like schedules, quizzes, grading, and uploads remain on **ILIAS**.)*
+
+---
+
+## Data Analysis & Uncertainty
+- **Uncertainty & Error Analysis (introductory)** – concise treatment of statistical vs. systematic effects; propagation rules and good practice.  
+- **Python for Data Analysis** – pandas/numpy/matplotlib basics; reproducible notebooks.  
+- **ROOT (for HEP-style analysis)** – histogramming, fits, I/O.
+
+> For hands-on examples, see **Appendix → Data Analysis** notebooks (Gaussian fit, bootstrap, background modeling).
+
+---
+
+## Detectors & Electronics
+- **Detector fundamentals** – signal formation, noise sources, readout chains.  
+- **Analog & Digital Electronics** – op-amps, filters, ADC/DAC, grounding/shielding, timing.
+
+*(Choose the titles that match your library’s availability; add DOIs/ISBNs as we collect them.)*
+
+---
+
+## Scientific Writing & Presentations
+- **IMRaD structure**, figure standards (labels, units, uncertainty bars), citation rules.  
+- **Slide design** for 40-min talks + 20-min discussion (clarity over density).
+
+---
+
+### How to Use This Library
+1. Start with **official module documents** and your experiment’s **PDF** in the *Experiments* section.  
+2. Use **Data Analysis & Uncertainty** when planning calibrations and error budgets.  
+3. Consult **Detectors & Electronics** for setup understanding and troubleshooting.  
+4. Follow **Scientific Writing** guidelines for reporting and seminar slides.

--- a/general-info/prerequisites.md
+++ b/general-info/prerequisites.md
@@ -1,0 +1,32 @@
+# Prerequisites for Successful Participation
+
+This handbook is short and on-point. Below are the **minimum expectations** to work safely and effectively in the Advanced Laboratory Classes (FP-I/FP-II/FP-EDU). Details and references are collected in the **[Library](../appendix/library.md)**.
+
+---
+
+## M.Sc. Students (PO 2020)
+See also the official **Handbook of Modules M.Sc. Physics (PO 2020)**:  
+<https://www.physik.uni-freiburg.de/bilderunddateien/dateien/MSc_Phys_Modulhandbuch_01.01.24.pdf>
+
+**Knowledge and skills expected:**
+- **Statistical methods of data analysis** and **experimental skills** (e.g., as acquired in *Physiklabor B*, B.Sc. program).
+- **Experimental methods** (in Freiburg e.g. lecture *Experimentelle Methoden*).
+- **Detectors & Electronics:** structure and functionality of common detector components; basics of **analog/digital circuits**.
+- **Evaluation methods:** proper treatment of **statistical vs. systematic uncertainties**; ability to **calculate/estimate** both.
+
+**Keywords:**  
+`Statistical data analysis` · `ROOT or Python for analysis` · `Basics of electronics` · `Digital & analog measurement technology` · `Basics of detectors`
+
+---
+
+## Practical Laboratory Experience
+- Completed multiple **beginners and advanced lab experiments** (nuclear/particle, atomic/molecular, solid-state, optics).  
+  Freiburg overview: <https://www.physik.uni-freiburg.de/studium-en/labore-en>
+- **Ready** to carry out, document, and **evaluate** advanced experiments.
+- Able to **operate modern measurement technology** properly.
+- **Advanced evaluation methods** (using analysis programs) are **mastered**.
+
+---
+
+## Where to go deeper
+See the **[Library](../appendix/library.md)** for recommended books, method guides (uncertainty, fitting), and official module documents.


### PR DESCRIPTION
## Summary
- add a concise prerequisites page for MSc students and lab readiness
- provide a library page listing official documents and key reference areas
- wire both new pages into the General Information and Appendix sections of the TOC

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6728ec8c88333b2f2dd290887da10