### PR TITLE
Ensure mermaid diagrams build in CI

### DIFF
--- a/.github/workflows/jb.yml
+++ b/.github/workflows/jb.yml
@@ -24,8 +24,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Install Jupyter Book
-        run: pip install -U jupyter-book
+      - name: Install documentation dependencies
+        run: pip install -U jupyter-book sphinxcontrib-mermaid
       - name: Build book
         run: jupyter-book build .
       - name: Deploy to gh-pages

--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,10 @@ html:
   extra_footer: |
     <p>© University of Freiburg – Advanced Lab. Text/figures: CC BY 4.0 · Code: MIT.</p>
 
+sphinx:
+  extra_extensions:
+    - sphinxcontrib.mermaid
+
 repository:
   url: https://github.com/physik-freiburg/advanced-lab-handbook
   branch: main

--- a/_toc.yml
+++ b/_toc.yml
@@ -21,5 +21,6 @@ parts:
       - file: appendix/data-analysis/overview
       - file: appendix/data-analysis/uncertainty
       - file: appendix/library
+      - file: appendix/quick-reference
       - file: appendix/references
       - file: appendix/templates

--- a/appendix/quick-reference.md
+++ b/appendix/quick-reference.md
@@ -1,0 +1,22 @@
+# Quick Reference Cards
+
+Short, printable checklists for on-site use.
+
+(safety-card)=
+## Safety
+- Always wear eye protection when lasers are active.  
+- Know your experiment’s emergency shut-off.  
+- Never work alone after hours.
+
+(imrad-card)=
+## IMRaD Report Skeleton
+- **Introduction** – Aim & context (½ page)  
+- **Methods** – Setup, formulas, parameters (1–2 pages)  
+- **Results** – Plots + uncertainties (2–3 pages)  
+- **Discussion** – Interpretation & improvements (1 page)
+
+(troubleshooting-card)=
+## Common Troubleshooting
+- **No signal?** → Check power, alignment, detector bias.  
+- **Noise?** → Verify grounding/shielding, signal cable, averaging.  
+- **Fit not converging?** → Check data range, initial guesses, units.

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -4,3 +4,4 @@ scipy
 matplotlib
 pandas
 jupyter-book
+sphinxcontrib-mermaid

--- a/intro.md
+++ b/intro.md
@@ -1,16 +1,79 @@
-# Advanced Lab Handbook (Quick Guide)
+# Advanced Lab Handbook – Quick Guide
 
-This handbook is intentionally **short and practical**.  
-Administrative items (schedules, team assignments, quizzes, grading, uploads) are **only on ILIAS**.
+Welcome!  
+This handbook is **intentionally short and practical**. It helps you navigate the Advanced Laboratory Classes (FP-I, FP-II, FP-EDU) efficiently.  
+Administrative items (schedules, team assignments, quizzes, grading, uploads) are handled **exclusively on [ILIAS](https://ilias.uni-freiburg.de/goto.php/crs/4019573)**.
 
-**Read this first:**
-- Preparation → what to do before day 1
-- Safety → rules you must follow
-- Writing → IMRaD report basics
-- Seminar → how to present results
+---
 
-For detailed methods and analysis how-tos, see **Appendix**.
-
-```{note}
-Go to the ILIAS course page for schedules, entrance/safety quizzes, grading sheets, and report uploads. This handbook hosts only open guidance.
+## 🧭 Where You Are in the Process
+```{mermaid}
+graph LR
+  A(Preparation) --> B(Safety) --> C(Experiments) --> D(Writing) --> E(Seminar)
 ```
+(≈ 5-min read per section)
+
+---
+
+## 🎯 Section Purpose – “Why This Matters”
+
+| Section | Focus | Why it matters |
+| --- | --- | --- |
+| Preparation | Before Day 1 | Complete these steps to hit the ground running. |
+| Safety | During lab work | Protect yourself and others; required for lab access. |
+| Experiments | Core activity | Apply scientific methods with precision and care. |
+| Writing | After measurements | Communicate your results clearly and honestly. |
+| Seminar | Final presentation | Share findings effectively with your peers. |
+
+---
+
+## 🧩 Quick References
+
+You can access concise reference cards any time:
+- {ref}`Safety Checklist <safety-card>`
+- {ref}`IMRaD Report Template <imrad-card>`
+- [Uncertainty & Data Analysis](appendix/data-analysis/uncertainty)
+- {ref}`Equipment Troubleshooting <troubleshooting-card>`
+
+---
+
+## ✅ Are You Ready?
+
+Before entering the lab, confirm you can:
+- Explain your experiment’s aim and expected signals.
+- Distinguish statistical from systematic uncertainties.
+- Operate lab instruments safely (after tutor introduction).
+- Record data in a reproducible way (chronological, clear, honest).
+- Follow the institute’s safety and honesty guidelines.
+
+You’re ready when you can check all boxes confidently.
+
+---
+
+## ⚖️ Scientific Honesty
+
+All work in this lab follows the [Principles of Good Scientific Practice](https://www.physik.uni-freiburg.de/redlichkeit-en).
+- Record every observation truthfully and in order.
+- Never delete or alter raw data; annotate corrections instead.
+- Cite all sources and collaborators transparently.
+- Report uncertainties even when results look “wrong.”
+- Uphold integrity: reproducibility > perfection.
+
+---
+
+## 🆘 Emergency & Contact
+- Emergency: 112 (internal phones: 0-112)
+- Institute safety officer: (to be confirmed)
+- Course organizers: fp@physik.uni-freiburg.de
+
+---
+
+## 📚 Explore Further
+
+Appendix topics available:
+- [Error & Uncertainty Analysis](appendix/data-analysis/uncertainty)
+- [Plotting & Fitting Guidelines](appendix/data-analysis/overview)
+- [LaTeX Tips & Report Templates](appendix/templates)
+- [Recommended Literature](appendix/library)
+
+---


### PR DESCRIPTION
## Summary
- label the quick reference sections and link to them from the intro using {ref} targets
- add the sphinxcontrib-mermaid dependency to both the binder environment and CI workflow
- rename the CI installation step to cover all documentation dependencies

## Testing
- `jupyter-book build .`


------
https://chatgpt.com/codex/tasks/task_e_68e677987d8c8333bc392f29193dbb2c