### PR TITLE
Add Binder-linked Gaussian fit and bootstrap demos

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -20,6 +20,14 @@ parts:
   - caption: Appendix
     chapters:
       - file: appendix/data-analysis/overview
+      - file: appendix/data-analysis/gaussian-fit
+        title: Gaussian Fit Walkthrough
+        options:
+          hidden: true
+      - file: appendix/data-analysis/bootstrap-resampling
+        title: Bootstrap Resampling Demo
+        options:
+          hidden: true
       - file: appendix/data-analysis/uncertainty
       - file: appendix/library
       - file: appendix/quick-reference

--- a/appendix/data-analysis/bootstrap-resampling.ipynb
+++ b/appendix/data-analysis/bootstrap-resampling.ipynb
@@ -1,0 +1,74 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c407d713",
+   "metadata": {},
+   "source": [
+    "# Bootstrap Resampling Demo\n",
+    "\n",
+    "Demonstrates estimating uncertainty in a sample mean via bootstrap resampling.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "028d0ce9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "np.random.seed(0)\n",
+    "N = 40\n",
+    "data = np.random.normal(loc=5.0, scale=2.0, size=N)\n",
+    "\n",
+    "# Bootstrap\n",
+    "n_boot = 1000\n",
+    "boot_means = np.array([\n",
+    "    np.mean(np.random.choice(data, size=N, replace=True))\n",
+    "    for _ in range(n_boot)\n",
+    "])\n",
+    "\n",
+    "mean = np.mean(data)\n",
+    "sigma_boot = np.std(boot_means)\n",
+    "\n",
+    "# Plot\n",
+    "plt.hist(boot_means, bins=25, color='lightblue', edgecolor='k')\n",
+    "plt.axvline(mean, color='r', lw=2, label=f\"mean = {mean:.2f}\")\n",
+    "plt.axvline(mean - sigma_boot, color='gray', ls='--')\n",
+    "plt.axvline(mean + sigma_boot, color='gray', ls='--')\n",
+    "plt.xlabel(\"Bootstrap sample mean\")\n",
+    "plt.ylabel(\"Frequency\")\n",
+    "plt.title(\"Bootstrap Resampling Demo\")\n",
+    "plt.legend()\n",
+    "plt.show()\n",
+    "\n",
+    "print(f\"Sample mean = {mean:.3f}\")\n",
+    "print(f\"Bootstrap σ ≈ {sigma_boot:.3f}\")\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/appendix/data-analysis/gaussian-fit.ipynb
+++ b/appendix/data-analysis/gaussian-fit.ipynb
@@ -1,25 +1,84 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# Gaussian Fit Walkthrough\n",
-        "This placeholder notebook will walk through fitting a Gaussian model to spectral data."
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.10"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "578daf54",
+   "metadata": {},
+   "source": [
+    "# Gaussian Fit Walkthrough\n",
+    "\n",
+    "Demonstrates curve fitting of synthetic Gaussian data with noise.\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d1656fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from scipy.optimize import curve_fit\n",
+    "\n",
+    "# Define model\n",
+    "def gaussian(x, A, mu, sigma):\n",
+    "    return A * np.exp(-(x - mu)**2 / (2*sigma**2))\n",
+    "\n",
+    "# Generate synthetic data\n",
+    "np.random.seed(42)\n",
+    "x = np.linspace(-5, 5, 60)\n",
+    "y_true = gaussian(x, A=1.0, mu=0.0, sigma=1.0)\n",
+    "y_noise = y_true + 0.05 * np.random.normal(size=len(x))\n",
+    "\n",
+    "# Fit model\n",
+    "popt, pcov = curve_fit(gaussian, x, y_noise, p0=[1, 0, 1])\n",
+    "A, mu, sigma = popt\n",
+    "perr = np.sqrt(np.diag(pcov))\n",
+    "\n",
+    "# Plot data and fit\n",
+    "plt.figure(figsize=(6, 4))\n",
+    "plt.scatter(x, y_noise, label='Data', color='steelblue')\n",
+    "plt.plot(x, gaussian(x, *popt), 'r-', label='Fit')\n",
+    "plt.xlabel(\"x\")\n",
+    "plt.ylabel(\"y\")\n",
+    "plt.legend()\n",
+    "plt.title(\"Gaussian Fit\")\n",
+    "\n",
+    "# Residuals\n",
+    "plt.figure(figsize=(6, 2))\n",
+    "plt.scatter(x, y_noise - gaussian(x, *popt), color='gray')\n",
+    "plt.axhline(0, color='k', lw=1)\n",
+    "plt.xlabel(\"x\")\n",
+    "plt.ylabel(\"Residuals\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print(f\"A = {A:.3f} ± {perr[0]:.3f}\")\n",
+    "print(f\"μ = {mu:.3f} ± {perr[1]:.3f}\")\n",
+    "print(f\"σ = {sigma:.3f} ± {perr[2]:.3f}\")\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/appendix/data-analysis/overview.md
+++ b/appendix/data-analysis/overview.md
@@ -1,15 +1,19 @@
 # Data Analysis – Overview
 
-Use this appendix for detailed methods:
-- Uncertainty propagation (statistical vs systematic)
-- Model fitting (residuals, goodness-of-fit)
-- Background modeling (e.g., linear + Gaussian)
-- Bootstrap / resampling (when and why)
+Interactive examples are available for direct exploration on Binder.
 
-Main pages stay short; link here when depth is needed.
+---
 
-**Interactive resources:**
-- {download}`Gaussian fit walkthrough <gaussian-fit.ipynb>`
-- {download}`Bootstrap resampling demo <bootstrap.ipynb>`
+## Gaussian Fit Walkthrough
+[![Launch Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/adv-labs-ufr/handbook/main?labpath=appendix/data-analysis/gaussian-fit.ipynb)
 
-See {doc}`/appendix/data-analysis/uncertainty` for deeper treatment of error analysis and {doc}`/appendix/quick-reference` for a concise checklist of key steps.
+A step-by-step example of fitting noisy Gaussian data using `scipy.optimize.curve_fit`.  
+Shows best-fit parameters, uncertainties, and residual plots.
+
+---
+
+## Bootstrap Resampling Demo
+[![Launch Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/adv-labs-ufr/handbook/main?labpath=appendix/data-analysis/bootstrap-resampling.ipynb)
+
+A short demo of estimating uncertainty in a sample mean by bootstrap resampling.  
+Illustrates the concept of **statistical variation** and how uncertainty emerges from repeated sampling.

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,13 @@
+name: advlab-handbook
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11
+  - jupyterlab
+  - numpy
+  - matplotlib
+  - scipy
+  - pip
+  - pip:
+      - jupyter-book
+      - sphinxcontrib-mermaid


### PR DESCRIPTION
## Summary
- add Gaussian fit and bootstrap resampling notebooks to the data analysis appendix
- configure the Binder environment and table of contents entries for the new demos
- refresh the overview page with Binder launch buttons for each notebook

## Testing
- `jupyter-book build .`


------
https://chatgpt.com/codex/tasks/task_e_68e68e46ed108333832ced97fbdf8210